### PR TITLE
fix(metadata): default provider to hosted rreading-glasses (api.bookinfo.pro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 > [!NOTE]
 > This repository is a maintenance fork for people who still depend on Readarr while the ecosystem waits for a real replacement to emerge. The intent is to keep existing installs usable and safer through security updates, dependency/runtime repair, packaging fixes, and selected breaking bug fixes; it is not a revival of Readarr as a feature-driven project, and new end-user features are out of scope by default. The container image built here keeps a LinuxServer-compatible runtime layout for existing homelab deployments.
 
+## Metadata provider
+
+The original Readarr metadata server (`api.bookinfo.club`) is gone (the domain no longer resolves), which left a clean install unable to search, add, or refresh books. To keep the app usable out of the box, this fork defaults the metadata source to the hosted [rreading-glasses](<https://github.com/blampe/rreading-glasses>) public instance at `https://api.bookinfo.pro` (Goodreads-backed).
+
+- **Third party, unsupported, use at your own risk.** It is a free community service run by others; this fork is not affiliated with it and cannot support it. Expect rate limits and possible downtime, and review its terms before relying on it.
+- **Overridable.** Change it under **Settings -> Development -> Metadata Source**. For Hardcover-backed metadata, use `https://hardcover.bookinfo.pro`. Clear the field to fall back to the (now dead) built-in default.
+- **Self-hosting (recommended for reliability).** Run your own with the `blampe/rreading-glasses:latest` image and point the override at it, e.g. `http://rreading-glasses:8788`.
+- **Caveat:** rreading-glasses formats some titles differently from the old server. Existing libraries may need a re-import/refresh of works with long subtitles.
+
 # Announcement: Retirement of Readarr
 
 We would like to announce that the [Readarr project](<https://github.com/Readarr/Readarr>) has been retired. This difficult decision was made due to a combination of factors: the project's metadata has become unusable, we no longer have the time to remake or repair it, and the community effort to transition to using Open Library as the source has stalled without much progress.

--- a/src/NzbDrone.Core.Test/Configuration/ConfigServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Configuration/ConfigServiceFixture.cs
@@ -35,6 +35,12 @@ namespace NzbDrone.Core.Test.Configuration
         }
 
         [Test]
+        public void metadata_source_should_default_to_public_bookinfo_instance()
+        {
+            Subject.MetadataSource.Should().Be("https://api.bookinfo.pro");
+        }
+
+        [Test]
         public void get_value_with_persist_should_store_default_value()
         {
             var salt = Subject.HmacSalt;

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -264,7 +264,11 @@ namespace NzbDrone.Core.Configuration
 
         public string MetadataSource
         {
-            get { return GetValue("MetadataSource", ""); }
+            // Default to the hosted rreading-glasses public instance. The original
+            // api.bookinfo.club server is dead (NXDOMAIN), so an empty default left
+            // fresh installs unable to search/add/refresh. Overridable at
+            // Settings -> Development -> Metadata Source.
+            get { return GetValue("MetadataSource", "https://api.bookinfo.pro"); }
 
             set { SetValue("MetadataSource", value); }
         }


### PR DESCRIPTION
## Problem
Readarr's original metadata server `api.bookinfo.club` is dead — the domain no longer resolves (NXDOMAIN). With `MetadataSource` defaulting to empty, `MetadataRequestBuilder` falls back to the hardcoded `https://api.bookinfo.club/v1/{route}`, so a **fresh install cannot search, add, or refresh** books. This is "metadata/provider availability that breaks core usage" — explicitly in the maintenance charter's scope.

## Fix
Default `ConfigService.MetadataSource` to the hosted [rreading-glasses](https://github.com/blampe/rreading-glasses) public instance `https://api.bookinfo.pro` (Goodreads-backed).

This reuses the already-wired `{MetadataSource}/{route}` override path in `MetadataRequestBuilder`, so:
- the dead `/v1` cloud builder is left untouched (host-swapping it would be wrong — see below),
- the **Settings → Development → Metadata Source** override is unchanged (clear the field to restore the old built-in default),
- existing installs with a stored value are unaffected.

## Verification
- **Path shape verified empirically** (the brief's must-check #1): the public instance serves BookInfo routes at the **root**, not `/v1`:
  - `GET https://api.bookinfo.pro/author/3389` → valid author JSON (`{"ForeignId":3389,"Name":"Stephen King",...}`)
  - `GET https://api.bookinfo.pro/v1/author/3389` → Swagger UI HTML (catch-all, 200 but not data)
  - So `{MetadataSource}/{route}` with no `/v1` is correct; host-swapping the legacy `/v1/` builder would hit the catch-all.
- **TDD**: added `ConfigServiceFixture.metadata_source_should_default_to_public_bookinfo_instance`; watched it fail (default was `""`), then pass. Full `ConfigServiceFixture` green (7 tests), incl. the key-collision reflection test.
- Built/tested with the CI analyzer profile (`-p:EnableAnalyzers=false -p:EnforceCodeStyleInBuild=false`). Did **not** run the full Docker image build locally.

## Docs
README gains a "Metadata provider" section: third-party/unsupported/at-your-own-risk, override location, Hardcover variant (`hardcover.bookinfo.pro`), self-hosting via `blampe/rreading-glasses:latest`, and the caveat that rreading-glasses formats some titles differently (existing libraries may need a re-import of works with long subtitles).

## Notes
- Goodreads (`api.bookinfo.pro`) chosen as default to match historical behavior; Hardcover is documented as the alternative.
- Third-party free service: kept fully overridable; self-hosting documented as the reliable fallback.