### PR TITLE
fix(docker): make /run/readarr-temp writable without CAP_CHOWN

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-readarr-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-readarr-config/run
@@ -3,6 +3,13 @@
 
 mkdir -p /run/readarr-temp
 
+# Make the temp dir writable under any UID even when CAP_CHOWN is unavailable.
+# Hardened/non-root runtimes (e.g. k8s dropping all caps) can't run the lsiown
+# below, leaving this root-owned and unwritable; ASP.NET DataProtection then
+# fails to write its scratch key and login returns 401. Sticky bit (same as
+# /tmp) keeps it shared-safe across users.
+chmod 1777 /run/readarr-temp
+
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     lsiown -R abc:abc \
         /config \


### PR DESCRIPTION
## Problem
Under a hardened non-root runtime (k8s `securityContext` dropping all caps, keeping only `SETUID`/`SETGID`), **login returns HTTP 401**:

```
[Error] AuthenticationController: Failed to authenticate user. An error occurred while trying to encrypt the provided data.
 ---> System.UnauthorizedAccessException: Access to the path '/run/readarr-temp/' is denied.
   at ...DataProtection...FileSystemXmlRepository.StoreElementCore
   at ...CookieAuthenticationHandler.HandleSignInAsync
```

## Root cause
- `Dockerfile` sets `TMPDIR=/run/readarr-temp`.
- The s6 init (`init-readarr-config/run`) does `mkdir -p` then `lsiown -R abc:abc`. `lsiown` (chown) needs **CAP_CHOWN**, which a hardened runtime doesn't grant, so the chown silently no-ops and the dir stays `root:root 0755`.
- The app runs as a non-root UID (PUID), so it can't write its `TMPDIR`. ASP.NET DataProtection mints a new key on login (the `/config/asp` keys are valid but expired), the scratch write is denied, cookie encryption throws → 401.

## Fix
Add `chmod 1777 /run/readarr-temp` after the `mkdir`. **chmod by the owner needs no capability** (unlike chown), so it works regardless of CAP_CHOWN. Sticky bit mirrors `/tmp` and prevents cross-user deletes. The `lsiown` block is kept for the normal root-start path.

Explicitly **not** done (per design): DataProtection keys stay in `/config/asp` (`{AppData}/asp`, `-data=/config`); `TMPDIR` stays ephemeral. Only the temp scratch is made writable.

## Verification
Reproduced the bug and confirmed the fix in a container with the **exact hardened cap set** (`--cap-drop ALL --cap-add SETUID --cap-add SETGID`):

| State | Perms | UID 1000 write |
|---|---|---|
| Before (`mkdir` as root; chown needs CAP_CHOWN) | `755 root:root` | DENIED (matches the 401) |
| After (`chmod 1777`) | `1777 root:root` | OK |

`shellcheck` + `bash -n` clean. Not run locally: full image build + live ASP.NET login (expired-key minting) — deferred to CI / deployment; the writable-TMPDIR root cause is directly verified.

## Follow-up
Once deployed, the infra-side `emptyDir` mount at `/run/readarr-temp` (infra PR #134) becomes redundant and can be removed.