### PR TITLE
chore: point fork links to iuliandita/readarr and note runtime stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 > [!NOTE]
 > This repository is a maintenance fork for people who still depend on Readarr while the ecosystem waits for a real replacement to emerge. The intent is to keep existing installs usable and safer through security updates, dependency/runtime repair, packaging fixes, and selected breaking bug fixes; it is not a revival of Readarr as a feature-driven project, and new end-user features are out of scope by default. The container image built here keeps a LinuxServer-compatible runtime layout for existing homelab deployments.
 
+Two things worth knowing about how this fork runs. The container is built on the [LinuxServer.io base image](https://github.com/linuxserver/docker-baseimage-alpine) and keeps its s6/PUID-PGID layout, so it drops into existing homelab setups ([LinuxServer docs](https://docs.linuxserver.io/)). For metadata, the original Readarr server is gone, so this fork defaults to the community [rreading-glasses](https://github.com/blampe/rreading-glasses) server (see the "Metadata provider" notes below to read more or self-host).
+
 ## Metadata provider
 
 The original Readarr metadata server (`api.bookinfo.club`) is gone (the domain no longer resolves), which left a clean install unable to search, add, or refresh books. To keep the app usable out of the box, this fork defaults the metadata source to the hosted [rreading-glasses](<https://github.com/blampe/rreading-glasses>) public instance at `https://api.bookinfo.pro` (Goodreads-backed).

--- a/frontend/src/System/Status/MoreInfo/MoreInfo.js
+++ b/frontend/src/System/Status/MoreInfo/MoreInfo.js
@@ -17,7 +17,7 @@ class MoreInfo extends Component {
         <DescriptionList>
           <DescriptionListItemTitle>Home page</DescriptionListItemTitle>
           <DescriptionListItemDescription>
-            <Link to="https://readarr.com/">readarr.com</Link>
+            <Link to="https://github.com/iuliandita/readarr">github.com/iuliandita/readarr</Link>
           </DescriptionListItemDescription>
 
           <DescriptionListItemTitle>Wiki</DescriptionListItemTitle>
@@ -37,12 +37,12 @@ class MoreInfo extends Component {
 
           <DescriptionListItemTitle>Source</DescriptionListItemTitle>
           <DescriptionListItemDescription>
-            <Link to="https://github.com/readarr/Readarr/">github.com/Readarr/Readarr</Link>
+            <Link to="https://github.com/iuliandita/readarr">github.com/iuliandita/readarr</Link>
           </DescriptionListItemDescription>
 
           <DescriptionListItemTitle>Feature Requests</DescriptionListItemTitle>
           <DescriptionListItemDescription>
-            <Link to="https://github.com/readarr/Readarr/issues">github.com/Readarr/Readarr/issues</Link>
+            <Link to="https://github.com/iuliandita/readarr/issues">github.com/iuliandita/readarr/issues</Link>
           </DescriptionListItemDescription>
 
         </DescriptionList>


### PR DESCRIPTION
## About -> More Info
Repoints the project-ownership links from the retired upstream to this fork:

| Field | Before | After |
|---|---|---|
| Home page | readarr.com | github.com/iuliandita/readarr |
| Source | github.com/Readarr/Readarr | github.com/iuliandita/readarr |
| Feature Requests | github.com/Readarr/Readarr/issues | github.com/iuliandita/readarr/issues |

Left the community links (**Wiki**, **Reddit**, **Discord**) untouched — they still resolve and aren't fork-owned. Easy to change too if you'd rather drop them.

## README
After the opening note, adds a short paragraph on how the fork runs, with read-more links for both pieces:
- the [LinuxServer.io base image](https://github.com/linuxserver/docker-baseimage-alpine) / [docs](https://docs.linuxserver.io/)
- the [rreading-glasses](https://github.com/blampe/rreading-glasses) metadata server

It points to the detailed "Metadata provider" section added in #32 (so this reads as the intro teaser, that as the detail — they're complementary; reconciled at merge).

## Verification
`yarn lint` clean. Cosmetic UI + docs only.