### PR TITLE
fix(api): bind JSON request bodies on .NET 10 (DryIoc + implicit FromServices)

### DIFF
--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -82,6 +82,17 @@ namespace NzbDrone.Host
                     .AllowAnyHeader());
             });
 
+            // Readarr swaps in DryIoc, whose IServiceProviderIsService reports any
+            // instantiable concrete type as resolvable. Since .NET 7, MVC implicitly
+            // infers [FromServices] for complex action parameters that the container
+            // claims to provide, so request bodies (e.g. CommandResource) were bound
+            // from DI as empty objects instead of deserialized from JSON. Opt out to
+            // restore body binding.
+            services.Configure<Microsoft.AspNetCore.Mvc.ApiBehaviorOptions>(options =>
+            {
+                options.DisableImplicitFromServicesParameters = true;
+            });
+
             services
             .AddControllers(options =>
             {

--- a/src/NzbDrone.Integration.Test/ApiTests/RequestBodyBindingFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/RequestBodyBindingFixture.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Integration.Test.Client;
+using RestSharp;
+
+namespace NzbDrone.Integration.Test.ApiTests
+{
+    // Regression guard for JSON request body binding.
+    //
+    // Readarr replaces the default DI container with DryIoc, whose
+    // IServiceProviderIsService reports any instantiable concrete type as
+    // resolvable. Since .NET 7, MVC implicitly infers [FromServices] for complex
+    // action parameters the container claims to provide. On the net6 -> net10
+    // upgrade this combination silently bound every POST/PUT body (e.g.
+    // CommandResource) from DI as an empty object instead of deserializing the
+    // JSON body, breaking every write endpoint. Startup opts out via
+    // ApiBehaviorOptions.DisableImplicitFromServicesParameters.
+    [TestFixture]
+    public class RequestBodyBindingFixture : IntegrationTest
+    {
+        [Test]
+        public void should_bind_json_request_body_to_model()
+        {
+            var response = Commands.Post(new SimpleCommandResource { Name = "rsssync" });
+
+            // Under the regression the body bound as an empty object, so Name was
+            // null and the request failed validation with a 400 before reaching here.
+            response.Id.Should().NotBe(0);
+            response.Name.Should().Be("rsssync");
+        }
+
+        [Test]
+        public void should_return_json_parse_error_for_malformed_body()
+        {
+            var request = new RestRequest("command")
+            {
+                Method = Method.POST
+            };
+            request.AddHeader("X-Api-Key", ApiKey);
+            request.AddParameter("application/json", "{{{bad", ParameterType.RequestBody);
+
+            var response = RestClient.Execute(request);
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+            // The body must actually be read by the JSON input formatter, producing a
+            // parse error -- not silently ignored and rejected by NotNull validation,
+            // which is the signature of the FromServices binding regression.
+            response.Content.Should().NotContain("NotNullValidator");
+            response.Content.Should().Contain("LineNumber");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Critical regression introduced by the net6 -> net10 upgrade (0.4.20 -> 0.4.22): **every JSON POST/PUT request body bound as an all-null object**, so all write API endpoints silently no-opped. Manual Refresh & Scan, manual Search, Add Author/Book, and all settings saves were non-functional. In-process scheduled tasks (RssSync, etc.) kept working, which masked the bug.

Reproduces on a fresh, empty `/config`:

```
curl -X POST localhost:8787/api/v1/command -H "X-Api-Key: $K" \
  -H 'Content-Type: application/json' -d '{"name":"RssSync"}'
# 0.4.20  -> 201 Created
# 0.4.22+ -> 400 [{"propertyName":"Name","errorCode":"NotNullValidator","propertyValue":null}]
```

## Root cause

Since .NET 7, MVC implicitly infers `[FromServices]` for complex action parameters that the DI container reports as resolvable (via `IServiceProviderIsService`). Readarr replaces the default container with **DryIoc**, whose `IServiceProviderIsService` treats any instantiable concrete type as resolvable. After the TFM bump, MVC therefore bound every request-body parameter (`CommandResource`, `RootFolderResource`, all settings resources) from the container as a freshly-constructed empty object instead of deserializing the JSON body. The body was never read (malformed JSON produced a NotNull validation error, not a parse error).

Confirmed live with diagnostics: the `commandResource` parameter's binding source was `Services`; the `SystemTextJsonInputFormatter` was registered correctly the whole time -- only binding-source selection upstream of it changed.

## Fix

Opt out of the implicit-FromServices inference globally:

```csharp
services.Configure<ApiBehaviorOptions>(options =>
{
    options.DisableImplicitFromServicesParameters = true;
});
```

This restores .NET 6 behaviour: complex parameters bind from the request body. Verified end-to-end against a freshly built net10 instance on a fresh config:

- `POST /api/v1/command {"name":"RssSync"}` -> **201**, body round-trips (`name == "RssSync"`)
- `POST /api/v1/rootfolder` -> Path and Name bind from body (no longer null)
- malformed JSON -> **400** with a JSON parse error (`LineNumber...`), not a null-model validation error

## Tests

Adds `RequestBodyBindingFixture` (integration) asserting the command body round-trips and that malformed JSON returns a parse error rather than the regression's null-model validation error. The bug only manifests through the real DryIoc + MVC pipeline, so an integration-level test is the correct guard.