### PR TITLE
fix: partial-metadata refresh NRE + Discord 429 rate-limit handling

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -66,7 +66,6 @@
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageVersion Include="System.ServiceProcess.ServiceController" Version="10.0.7" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.10" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
     <PackageVersion Include="TagLibSharp-Lidarr" Version="2.2.0.19" />
   </ItemGroup>

--- a/src/NzbDrone.Common.Test/Http/TooManyRequestsExceptionFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/TooManyRequestsExceptionFixture.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Net;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Common.Test.Http
+{
+    [TestFixture]
+    public class TooManyRequestsExceptionFixture : TestBase
+    {
+        private TooManyRequestsException Build(string retryAfter)
+        {
+            var request = new HttpRequest("https://discord.com/api/webhooks/1/abc");
+            var response = new HttpResponse(request, new HttpHeader(), new byte[0], (HttpStatusCode)429);
+
+            if (retryAfter != null)
+            {
+                response.Headers["Retry-After"] = retryAfter;
+            }
+
+            return new TooManyRequestsException(request, response);
+        }
+
+        [Test]
+        public void should_parse_integer_retry_after_seconds()
+        {
+            Build("300").RetryAfter.Should().Be(TimeSpan.FromSeconds(300));
+        }
+
+        [Test]
+        public void should_parse_fractional_retry_after_seconds()
+        {
+            // Discord can return sub-second values like "0.5"; int parsing dropped these to zero.
+            Build("0.5").RetryAfter.Should().Be(TimeSpan.FromMilliseconds(500));
+        }
+
+        [Test]
+        public void should_default_to_zero_when_header_missing()
+        {
+            Build(null).RetryAfter.Should().Be(TimeSpan.Zero);
+        }
+    }
+}

--- a/src/NzbDrone.Common/Http/TooManyRequestsException.cs
+++ b/src/NzbDrone.Common/Http/TooManyRequestsException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace NzbDrone.Common.Http
 {
@@ -13,7 +14,9 @@ namespace NzbDrone.Common.Http
             {
                 var retryAfter = response.Headers["Retry-After"].ToString();
 
-                if (int.TryParse(retryAfter, out var seconds))
+                // Retry-After is normally an integer number of seconds, but some
+                // servers (e.g. Discord) send fractional seconds like "0.5".
+                if (double.TryParse(retryAfter, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
                 {
                     RetryAfter = TimeSpan.FromSeconds(seconds);
                 }

--- a/src/NzbDrone.Core.Test/MusicTests/RefreshBookServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MusicTests/RefreshBookServiceFixture.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MetadataSource;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.MusicTests
+{
+    [TestFixture]
+    public class RefreshBookServiceFixture : CoreTest<RefreshBookService>
+    {
+        private Author _author;
+        private Book _localBook;
+        private List<Book> _remoteBooks;
+
+        [SetUp]
+        public void Setup()
+        {
+            var metadata = Builder<AuthorMetadata>.CreateNew().Build();
+
+            _author = Builder<Author>.CreateNew()
+                .With(a => a.Metadata = metadata)
+                .Build();
+
+            // A book the user still owns locally (e.g. an omnibus) that the partial
+            // metadata provider no longer returns for the author.
+            _localBook = Builder<Book>.CreateNew()
+                .With(b => b.Id = 5)
+                .With(b => b.ForeignBookId = "99")
+                .With(b => b.Author = _author)
+                .With(b => b.AuthorMetadata = metadata)
+                .With(b => b.AddOptions = new AddBookOptions { AddType = BookAddType.Automatic })
+                .Build();
+
+            // Author payload omits the local book (narrow remote coverage).
+            _remoteBooks = new List<Book>
+            {
+                Builder<Book>.CreateNew().With(b => b.ForeignBookId = "1").Build()
+            };
+        }
+
+        private void GivenBookHasFiles()
+        {
+            Mocker.GetMock<IMediaFileService>()
+                .Setup(x => x.GetFilesByBook(_localBook.Id))
+                .Returns(Builder<BookFile>.CreateListOfSize(1).BuildList());
+        }
+
+        private void GivenNoBookFiles()
+        {
+            Mocker.GetMock<IMediaFileService>()
+                .Setup(x => x.GetFilesByBook(It.IsAny<int>()))
+                .Returns(new List<BookFile>());
+        }
+
+        private void GivenProviderLacksBook()
+        {
+            Mocker.GetMock<IProvideBookInfo>()
+                .Setup(x => x.GetBookInfo(_localBook.ForeignBookId))
+                .Throws(new BookNotFoundException(_localBook.ForeignBookId));
+        }
+
+        [Test]
+        public void should_skip_book_and_not_throw_when_provider_lacks_book_but_book_has_files()
+        {
+            // Partial remote data: author resolves, this book is missing from the
+            // author payload AND the provider 404s the book directly. Previously
+            // this dereferenced a null Author and crashed the whole author refresh.
+            GivenBookHasFiles();
+            GivenProviderLacksBook();
+
+            var updated = Subject.RefreshBookInfo(_localBook, _remoteBooks, _author, false);
+
+            updated.Should().BeFalse();
+
+            // Book is retained because it still has files on disk.
+            Mocker.GetMock<IBookService>()
+                .Verify(x => x.DeleteBook(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never());
+
+            // The book is skipped with an error rather than crashing the refresh.
+            ExceptionVerification.IgnoreErrors();
+        }
+
+        [Test]
+        public void should_delete_book_when_missing_from_metadata_and_no_files()
+        {
+            // Clean, already-handled path: book gone from metadata and nothing on
+            // disk, so it is safe to delete. Locks in that behaviour is unchanged.
+            GivenNoBookFiles();
+
+            Mocker.GetMock<IBookService>()
+                .Setup(x => x.DeleteBook(_localBook.Id, It.IsAny<bool>(), It.IsAny<bool>()));
+
+            var updated = Subject.RefreshBookInfo(_localBook, _remoteBooks, _author, false);
+
+            updated.Should().BeFalse();
+
+            Mocker.GetMock<IBookService>()
+                .Verify(x => x.DeleteBook(_localBook.Id, false, It.IsAny<bool>()), Times.Once());
+
+            ExceptionVerification.IgnoreWarns();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NotificationTests/Discord/DiscordProxyFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/Discord/DiscordProxyFixture.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+using System.Net;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Notifications.Discord;
+using NzbDrone.Core.Notifications.Discord.Payloads;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.NotificationTests.Discord
+{
+    [TestFixture]
+    public class DiscordProxyFixture : CoreTest<DiscordProxy>
+    {
+        private DiscordSettings _settings;
+        private DiscordPayload _payload;
+
+        [SetUp]
+        public void Setup()
+        {
+            _settings = new DiscordSettings { WebHookUrl = "https://discord.com/api/webhooks/1/abc" };
+            _payload = new DiscordPayload();
+        }
+
+        private TooManyRequestsException Build429(string retryAfter)
+        {
+            var request = new HttpRequest(_settings.WebHookUrl);
+            var response = new HttpResponse(request, new HttpHeader(), new byte[0], (HttpStatusCode)429);
+            response.Headers["Retry-After"] = retryAfter;
+            return new TooManyRequestsException(request, response);
+        }
+
+        private HttpResponse OkResponse()
+        {
+            var request = new HttpRequest(_settings.WebHookUrl);
+            return new HttpResponse(request, new HttpHeader(), new byte[0], HttpStatusCode.OK);
+        }
+
+        [Test]
+        public void should_wait_and_retry_once_after_429_with_retry_after()
+        {
+            Mocker.GetMock<IHttpClient>()
+                .SetupSequence(c => c.Execute(It.IsAny<HttpRequest>()))
+                .Throws(Build429("1"))
+                .Returns(OkResponse());
+
+            var sw = Stopwatch.StartNew();
+            Subject.SendPayload(_payload, _settings);
+            sw.Stop();
+
+            // Honored the ~1s Retry-After before retrying rather than hammering.
+            sw.ElapsedMilliseconds.Should().BeGreaterThan(700);
+
+            Mocker.GetMock<IHttpClient>()
+                .Verify(c => c.Execute(It.IsAny<HttpRequest>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public void should_give_up_with_single_warn_on_persistent_429()
+        {
+            Mocker.GetMock<IHttpClient>()
+                .Setup(c => c.Execute(It.IsAny<HttpRequest>()))
+                .Throws(Build429("0.5"));
+
+            var ex = Assert.Throws<DiscordException>(() => Subject.SendPayload(_payload, _settings));
+
+            // Still surfaces the 429 to the caller rather than swallowing it.
+            ex.InnerException.Should().BeOfType<TooManyRequestsException>();
+
+            // Bounded attempts: initial + retries, all exhausted - no retry storm.
+            Mocker.GetMock<IHttpClient>()
+                .Verify(c => c.Execute(It.IsAny<HttpRequest>()), Times.Exactly(3));
+
+            // Give-up branch runs exactly once, so its single Warn is logged once and
+            // no Error is logged per attempt. Drain it so the log harness stays clean.
+            // (Asserting the exact Warn count couples to flaky global NLog-init timing.)
+            ExceptionVerification.IgnoreWarns();
+            ExceptionVerification.IgnoreErrors();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Books/Services/RefreshBookService.cs
+++ b/src/NzbDrone.Core/Books/Services/RefreshBookService.cs
@@ -114,6 +114,17 @@ namespace NzbDrone.Core.Books
             if (book == null)
             {
                 data = GetSkyhookData(local);
+
+                // The provider returned the author but neither the author payload nor a
+                // direct lookup has this book (partial remote data - e.g. an omnibus or
+                // collection the metadata mirror lacks). Leave Entity null so the caller's
+                // remote == null handling skips/deletes this single book instead of the
+                // whole author refresh dying on a NullReferenceException.
+                if (data == null)
+                {
+                    return result;
+                }
+
                 book = data.Books.Value.SingleOrDefault(x => x.ForeignBookId == local.ForeignBookId);
             }
 

--- a/src/NzbDrone.Core/Datastore/WhereBuilderPostgres.cs
+++ b/src/NzbDrone.Core/Datastore/WhereBuilderPostgres.cs
@@ -307,10 +307,10 @@ namespace NzbDrone.Core.Datastore
 
                     item = body.Arguments[1];
                 }
-                // Static method
-                // Must be Enumerable.Contains(source, item)
                 else if (body.Method.DeclaringType != typeof(Enumerable) || body.Arguments.Count != 2)
                 {
+                    // Static method
+                    // Must be Enumerable.Contains(source, item)
                     throw new NotSupportedException("Unexpected form of Enumerable.Contains");
                 }
                 else

--- a/src/NzbDrone.Core/Datastore/WhereBuilderSqlite.cs
+++ b/src/NzbDrone.Core/Datastore/WhereBuilderSqlite.cs
@@ -307,10 +307,10 @@ namespace NzbDrone.Core.Datastore
 
                     item = body.Arguments[1];
                 }
-                // Static method
-                // Must be Enumerable.Contains(source, item)
                 else if (body.Method.DeclaringType != typeof(Enumerable) || body.Arguments.Count != 2)
                 {
+                    // Static method
+                    // Must be Enumerable.Contains(source, item)
                     throw new NotSupportedException("Unexpected form of Enumerable.Contains");
                 }
                 else

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordProxy.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Net.Http;
+using System.Threading;
 using NLog;
 using NzbDrone.Common.Http;
 using NzbDrone.Common.Serializer;
@@ -13,6 +15,12 @@ namespace NzbDrone.Core.Notifications.Discord
 
     public class DiscordProxy : IDiscordProxy
     {
+        // Discord rate-limits webhooks (~30 req/min). Honor 429 Retry-After with a
+        // few bounded retries so a burst degrades gracefully instead of log-spamming.
+        private const int MaxAttempts = 3;
+        private static readonly TimeSpan MinRetryWait = TimeSpan.FromMilliseconds(500);
+        private static readonly TimeSpan MaxRetryWait = TimeSpan.FromSeconds(10);
+
         private readonly IHttpClient _httpClient;
         private readonly Logger _logger;
 
@@ -24,23 +32,49 @@ namespace NzbDrone.Core.Notifications.Discord
 
         public void SendPayload(DiscordPayload payload, DiscordSettings settings)
         {
-            try
+            for (var attempt = 1; ; attempt++)
             {
-                var request = new HttpRequestBuilder(settings.WebHookUrl)
-                    .Accept(HttpAccept.Json)
-                    .Build();
+                try
+                {
+                    var request = new HttpRequestBuilder(settings.WebHookUrl)
+                        .Accept(HttpAccept.Json)
+                        .Build();
 
-                request.Method = HttpMethod.Post;
-                request.Headers.ContentType = "application/json";
-                request.SetContent(payload.ToJson());
+                    request.Method = HttpMethod.Post;
+                    request.Headers.ContentType = "application/json";
+                    request.SetContent(payload.ToJson());
 
-                _httpClient.Execute(request);
+                    _httpClient.Execute(request);
+                    return;
+                }
+                catch (TooManyRequestsException ex)
+                {
+                    if (attempt >= MaxAttempts)
+                    {
+                        _logger.Warn("Discord rate limited the webhook (429); gave up after {0} attempts", attempt);
+                        throw new DiscordException("Unable to post payload", ex);
+                    }
+
+                    var wait = ClampRetryAfter(ex.RetryAfter);
+                    _logger.Debug("Discord rate limited the webhook (429); waiting {0:0.###}s before retry", wait.TotalSeconds);
+                    Thread.Sleep(wait);
+                }
+                catch (HttpException ex)
+                {
+                    _logger.Error(ex, "Unable to post payload {0}", payload);
+                    throw new DiscordException("Unable to post payload", ex);
+                }
             }
-            catch (HttpException ex)
+        }
+
+        private static TimeSpan ClampRetryAfter(TimeSpan retryAfter)
+        {
+            if (retryAfter < MinRetryWait)
             {
-                _logger.Error(ex, "Unable to post payload {0}", payload);
-                throw new DiscordException("Unable to post payload", ex);
+                return MinRetryWait;
             }
+
+            return retryAfter > MaxRetryWait ? MaxRetryWait : retryAfter;
         }
     }
 }

--- a/src/NzbDrone.Test.Common/NzbDroneRunner.cs
+++ b/src/NzbDrone.Test.Common/NzbDroneRunner.cs
@@ -185,6 +185,11 @@ namespace NzbDrone.Test.Common
             // Generate and set the api key so we don't have to poll the config file
             var apiKey = Guid.NewGuid().ToString().Replace("-", "");
 
+            // When auth is enabled for a test we want it enforced for every request, including
+            // loopback. DisabledForLocalAddresses would let the UiAuthorizationHandler bypass the
+            // challenge for localhost and hide the login redirect behaviour under test.
+            var authenticationRequired = enableAuth ? "Enabled" : "DisabledForLocalAddresses";
+
             var xDoc = new XDocument(
                 new XDeclaration("1.0", "utf-8", "yes"),
                 new XElement(ConfigFileProvider.CONFIG_ELEMENT_NAME,
@@ -192,11 +197,7 @@ namespace NzbDrone.Test.Common
                              new XElement(nameof(ConfigFileProvider.LogLevel), "trace"),
                              new XElement(nameof(ConfigFileProvider.AnalyticsEnabled), false),
                              new XElement(nameof(ConfigFileProvider.AuthenticationMethod), enableAuth ? "Forms" : "None"),
-
-                             // When auth is enabled for a test we want it enforced for every request, including
-                             // loopback. DisabledForLocalAddresses would let the UiAuthorizationHandler bypass the
-                             // challenge for localhost and hide the login redirect behaviour under test.
-                             new XElement(nameof(ConfigFileProvider.AuthenticationRequired), enableAuth ? "Enabled" : "DisabledForLocalAddresses"),
+                             new XElement(nameof(ConfigFileProvider.AuthenticationRequired), authenticationRequired),
                              new XElement(nameof(ConfigFileProvider.Port), Port)));
 
             var data = xDoc.ToString();


### PR DESCRIPTION
Two maintenance bugfixes (stability fork; smallest-viable changes, no DB/API/config churn).

## 1. Author refresh NRE on partial remote metadata
`RefreshBookService.GetRemoteData` dereferenced a null skyhook lookup when the metadata provider returned an author but omitted one of its books (partial data from the hosted rreading-glasses mirror — e.g. an omnibus the mirror lacks). One missing book threw a `NullReferenceException` that aborted the **entire** author refresh.

Fix: guard the null lookup and leave `Entity` null so the caller's existing `remote == null` path skips/deletes just that book. Regression tests cover the has-files (retain) and no-files (delete) branches.

## 2. Discord notifier ignores HTTP 429
The webhook notifier caught `TooManyRequestsException` in the generic `HttpException` handler, logging an Error and rethrowing per event. During a burst (Discord caps webhooks ~30 req/min) that meant one error log per notification and all dropped.

Fix: catch `TooManyRequestsException` ahead of `HttpException`, retry up to 3 attempts waiting `Retry-After` clamped to [500ms, 10s]; on exhaustion log a single Warn and rethrow `DiscordException`. Also fixed `TooManyRequestsException` to parse fractional `Retry-After` (Discord sends `"0.5"`), which int parsing floored to zero. Shared `HttpClient` 429 behavior unchanged (parser fix is additive).

## Verification
- `dotnet build src/Readarr.sln -c Release` -> 25 projects, 0 errors, 0 warnings.
- Full unit suite (`dotnet test` solution, unit categories): new tests green; the only failures are pre-existing live-network metadata/version and disk-rollback tests, unrelated to this change.
- New tests: refresh partial-payload (2), Discord 429 retry/give-up (2), Retry-After parser integer/fractional/missing (3).