### PR TITLE
fix(events): guard null lazy relations in BookFileDeletedEvent handlers

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
@@ -210,14 +210,17 @@ namespace NzbDrone.Core.MediaFiles
 
             if (_configService.DeleteEmptyFolders)
             {
-                var author = message.BookFile.Author.Value;
+                // Author can already be gone when the file is orphaned or the author is removed
+                // in the same operation. Without the author path there is no folder to collapse
+                // upwards to, but the book folder itself can still be cleaned.
+                var author = message.BookFile.Author?.Value;
                 var bookFolder = message.BookFile.Path.GetParentPath();
 
-                if (_diskProvider.GetFiles(author.Path, true).Empty())
+                if (author != null && _diskProvider.GetFiles(author.Path, true).Empty())
                 {
                     _diskProvider.DeleteFolder(author.Path, true);
                 }
-                else if (_diskProvider.GetFiles(bookFolder, true).Empty())
+                else if (bookFolder.IsNotNullOrWhiteSpace() && _diskProvider.GetFiles(bookFolder, true).Empty())
                 {
                     _diskProvider.RemoveEmptySubfolders(bookFolder);
                 }

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -278,13 +278,25 @@ namespace NzbDrone.Core.Notifications
 
         public void Handle(BookFileDeletedEvent message)
         {
+            // The edition and author rows can already be gone by the time this fires (orphaned
+            // file, or the author removed in the same operation), and LazyLoaded.Value is null
+            // then. Throwing here aborts the whole handler chain, so skip instead.
+            var author = message.BookFile.Author?.Value;
+            var deletedBook = message.BookFile.Edition?.Value?.Book?.Value;
+
+            if (author == null || deletedBook == null)
+            {
+                _logger.Debug("Skipping OnBookFileDelete notification for {0}: author or edition is no longer available", message.BookFile.Path);
+                return;
+            }
+
             var deleteMessage = new BookFileDeleteMessage();
 
-            var book = new List<Book> { message.BookFile.Edition.Value.Book };
+            var book = new List<Book> { deletedBook };
 
-            deleteMessage.Message = GetMessage(message.BookFile.Author, book, message.BookFile.Quality);
+            deleteMessage.Message = GetMessage(author, book, message.BookFile.Quality);
             deleteMessage.BookFile = message.BookFile;
-            deleteMessage.Book = message.BookFile.Edition.Value.Book;
+            deleteMessage.Book = deletedBook;
             deleteMessage.Reason = message.Reason;
 
             foreach (var notification in _notificationFactory.OnBookFileDeleteEnabled())
@@ -293,7 +305,7 @@ namespace NzbDrone.Core.Notifications
                 {
                     if (message.Reason != MediaFiles.DeleteMediaFileReason.Upgrade || ((NotificationDefinition)notification.Definition).OnBookFileDeleteForUpgrade)
                     {
-                        if (ShouldHandleAuthor(notification.Definition, message.BookFile.Author))
+                        if (ShouldHandleAuthor(notification.Definition, author))
                         {
                             notification.OnBookFileDelete(deleteMessage);
                             _notificationStatusService.RecordSuccess(notification.Definition.Id);

--- a/src/Readarr.Api.V1/Books/BookController.cs
+++ b/src/Readarr.Api.V1/Books/BookController.cs
@@ -247,7 +247,14 @@ namespace Readarr.Api.V1.Books
                 return;
             }
 
-            BroadcastResourceChange(ModelAction.Updated, MapToResource(message.BookFile.Edition.Value.Book.Value, true));
+            var book = message.BookFile.Edition?.Value?.Book?.Value;
+
+            if (book == null)
+            {
+                return;
+            }
+
+            BroadcastResourceChange(ModelAction.Updated, MapToResource(book, true));
         }
     }
 }


### PR DESCRIPTION
Fixes #52

## What

`BookFileDeletedEvent` threw `NullReferenceException` out of three handlers whenever the deleted file's author or edition row was already gone. Observed live on v10.0.0.22751 during a 159-file delete batch.

## Why it matters

`MediaFileDeletionService` is the handler that removes empty author and book folders. Every throw left an empty directory behind, and `NotificationService` never sent the delete notification.

## How

Null-check the `LazyLoaded` relations and skip only the work that depends on them:

- `MediaFileDeletionService` - without an author there is no author path to collapse upwards to, but the book folder can still be cleaned. Also guards an empty `bookFolder`.
- `NotificationService` - nothing to report without an author and a book, so return early with a debug line. Reuses the already-resolved author for `ShouldHandleAuthor` instead of re-dereferencing.
- `BookController` - nothing to broadcast without a book, so return early.

## Verification

`dotnet msbuild -restore src/Readarr.sln -p:Configuration=Release -p:Platform=Posix` - 0 warnings, 0 errors.