### PR TITLE
feat(importlist): make the Import List Sync interval configurable

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -109,6 +109,13 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("RssSyncInterval", value); }
         }
 
+        public int ImportListSyncInterval
+        {
+            get { return GetValueInt("ImportListSyncInterval", 5); }
+
+            set { SetValue("ImportListSyncInterval", value); }
+        }
+
         public int MaximumSize
         {
             get { return GetValueInt("MaximumSize", 0); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -46,6 +46,7 @@ namespace NzbDrone.Core.Configuration
         //Indexers
         int Retention { get; set; }
         int RssSyncInterval { get; set; }
+        int ImportListSyncInterval { get; set; }
         int MaximumSize { get; set; }
         int MinimumAge { get; set; }
 

--- a/src/NzbDrone.Core/Jobs/TaskManager.cs
+++ b/src/NzbDrone.Core/Jobs/TaskManager.cs
@@ -116,7 +116,7 @@ namespace NzbDrone.Core.Jobs
 
                     new ScheduledTask
                     {
-                        Interval = 5,
+                        Interval = GetImportListSyncInterval(),
                         TypeName = typeof(ImportListSyncCommand).FullName
                     },
 
@@ -170,6 +170,23 @@ namespace NzbDrone.Core.Jobs
             return interval * 60 * 24;
         }
 
+        private int GetImportListSyncInterval()
+        {
+            var interval = _configService.ImportListSyncInterval;
+
+            if (interval > 0 && interval < 10)
+            {
+                return 10;
+            }
+
+            if (interval < 0)
+            {
+                return 0;
+            }
+
+            return interval;
+        }
+
         private int GetRssSyncInterval()
         {
             var interval = _configService.RssSyncInterval;
@@ -215,10 +232,14 @@ namespace NzbDrone.Core.Jobs
             var backup = _scheduledTaskRepository.GetDefinition(typeof(BackupCommand));
             backup.Interval = GetBackupInterval();
 
-            _scheduledTaskRepository.UpdateMany(new List<ScheduledTask> { rss, backup });
+            var importList = _scheduledTaskRepository.GetDefinition(typeof(ImportListSyncCommand));
+            importList.Interval = GetImportListSyncInterval();
+
+            _scheduledTaskRepository.UpdateMany(new List<ScheduledTask> { rss, backup, importList });
 
             _cache.Find(rss.TypeName).Interval = rss.Interval;
             _cache.Find(backup.TypeName).Interval = backup.Interval;
+            _cache.Find(importList.TypeName).Interval = importList.Interval;
         }
     }
 }

--- a/src/Readarr.Api.V1/Config/ImportListConfigController.cs
+++ b/src/Readarr.Api.V1/Config/ImportListConfigController.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using NzbDrone.Core.Configuration;
+using Readarr.Http;
+
+namespace Readarr.Api.V1.Config
+{
+    [V1ApiController("config/importlist")]
+    public class ImportListConfigController : ConfigController<ImportListConfigResource>
+    {
+        public ImportListConfigController(IConfigService configService)
+            : base(configService)
+        {
+            SharedValidator.RuleFor(c => c.ImportListSyncInterval)
+                           .Must(interval => interval == 0 || interval >= 10)
+                           .WithMessage("Should be 0 to disable, or 10 minutes or more");
+        }
+
+        protected override ImportListConfigResource ToResource(IConfigService model)
+        {
+            return ImportListConfigResourceMapper.ToResource(model);
+        }
+    }
+}

--- a/src/Readarr.Api.V1/Config/ImportListConfigResource.cs
+++ b/src/Readarr.Api.V1/Config/ImportListConfigResource.cs
@@ -1,0 +1,21 @@
+using NzbDrone.Core.Configuration;
+using Readarr.Http.REST;
+
+namespace Readarr.Api.V1.Config
+{
+    public class ImportListConfigResource : RestResource
+    {
+        public int ImportListSyncInterval { get; set; }
+    }
+
+    public static class ImportListConfigResourceMapper
+    {
+        public static ImportListConfigResource ToResource(IConfigService model)
+        {
+            return new ImportListConfigResource
+            {
+                ImportListSyncInterval = model.ImportListSyncInterval
+            };
+        }
+    }
+}


### PR DESCRIPTION
Fixes #53

## What

`TaskManager` registered `ImportListSyncCommand` with a hardcoded `Interval = 5` and re-applied that value to the stored definition on every startup, so the interval could not be changed from the UI, the API, or the database.

## Why it matters

288 syncs per day per instance against upstream providers that change on a scale of days. Measured on a live pair of instances sharing one Goodreads bookshelf:

```
Warn|GoodreadsBookshelf|Error fetching bookshelves from Goodreads
HTTP request failed: [500:InternalServerError] [GET]
  https://www.goodreads.com/review/list.xml?...&per_page=200&page=10
Info|ImportListSyncService|Processing 1797 list items
```

The instance polling the same shelf less often read 2433 items from it. The truncation is silent - the sync reports success.

It also drives avoidable load on Prowlarr, which answers `t=caps` with `429.TooManyRequests`.

## How

Follows the existing `RssSyncInterval` pattern exactly:

- `IConfigService` / `ConfigService` - `ImportListSyncInterval`, default 5, so behaviour is unchanged for anyone who does not set it
- `TaskManager` - `GetImportListSyncInterval()` with the same floor as RSS (0 disables, anything between 1 and 9 is raised to 10), and the task definition is refreshed on `ConfigSavedEvent` so a change applies without a restart
- `ImportListConfigResource` / `ImportListConfigController` at `config/importlist`, mirroring `config/indexer`

No UI field yet - the value is settable over the API. Worth a follow-up under Settings > Lists next to the existing Indexer Options field.

## Verification

`dotnet msbuild -restore src/Readarr.sln -p:Configuration=Release -p:Platform=Posix` - 0 errors.